### PR TITLE
1.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'net.minecraftforge.gradle' version '[6.0,6.2)'
 }
 
-version = '1.0.0'
+version = '1.0.1'
 group = 'com.environs'
 
 base {

--- a/src/main/java/com/environs/listeners/RenderGuiOverlayEventListener.java
+++ b/src/main/java/com/environs/listeners/RenderGuiOverlayEventListener.java
@@ -17,13 +17,14 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderGuiOverlayEvent;
 import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 
-@Mod.EventBusSubscriber(bus = EventBusSubscriber.Bus.FORGE)
+@Mod.EventBusSubscriber(bus = EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
 public final class RenderGuiOverlayEventListener {
 	private static long fadeDimensionTimer;
 	private static long fadeBiomeTimer;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,7 +5,7 @@ license="All Rights Reserved"
 
 [[mods]]
     displayName="Environs"    
-    version="1.0.0"
+    version="1.0.1"
     modId="environs"
     credits="Skullmaster31 - collaboration/testing"
     authors="burnsqc"


### PR DESCRIPTION
Fixed bug which causes crash when attempting to launch server with Environs 1.0.0 installed.

Root cause was failure to specify Dist.CLIENT in RenderGuiOverlayEventListener.